### PR TITLE
Add Gemini embedding engine

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -2307,6 +2307,17 @@ RAG_AZURE_OPENAI_API_VERSION = PersistentConfig(
     os.getenv("RAG_AZURE_OPENAI_API_VERSION", ""),
 )
 
+RAG_GEMINI_API_BASE_URL = PersistentConfig(
+    "RAG_GEMINI_API_BASE_URL",
+    "rag.gemini.base_url",
+    os.getenv("RAG_GEMINI_API_BASE_URL", GEMINI_API_BASE_URL),
+)
+RAG_GEMINI_API_KEY = PersistentConfig(
+    "RAG_GEMINI_API_KEY",
+    "rag.gemini.api_key",
+    os.getenv("RAG_GEMINI_API_KEY", GEMINI_API_KEY),
+)
+
 RAG_OLLAMA_BASE_URL = PersistentConfig(
     "RAG_OLLAMA_BASE_URL",
     "rag.ollama.url",

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -218,6 +218,8 @@ from open_webui.config import (
     RAG_AZURE_OPENAI_BASE_URL,
     RAG_AZURE_OPENAI_API_KEY,
     RAG_AZURE_OPENAI_API_VERSION,
+    RAG_GEMINI_API_BASE_URL,
+    RAG_GEMINI_API_KEY,
     RAG_OLLAMA_BASE_URL,
     RAG_OLLAMA_API_KEY,
     CHUNK_OVERLAP,
@@ -779,6 +781,9 @@ app.state.config.RAG_AZURE_OPENAI_BASE_URL = RAG_AZURE_OPENAI_BASE_URL
 app.state.config.RAG_AZURE_OPENAI_API_KEY = RAG_AZURE_OPENAI_API_KEY
 app.state.config.RAG_AZURE_OPENAI_API_VERSION = RAG_AZURE_OPENAI_API_VERSION
 
+app.state.config.RAG_GEMINI_API_BASE_URL = RAG_GEMINI_API_BASE_URL
+app.state.config.RAG_GEMINI_API_KEY = RAG_GEMINI_API_KEY
+
 app.state.config.RAG_OLLAMA_BASE_URL = RAG_OLLAMA_BASE_URL
 app.state.config.RAG_OLLAMA_API_KEY = RAG_OLLAMA_API_KEY
 
@@ -878,7 +883,11 @@ app.state.EMBEDDING_FUNCTION = get_embedding_function(
         else (
             app.state.config.RAG_OLLAMA_BASE_URL
             if app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
-            else app.state.config.RAG_AZURE_OPENAI_BASE_URL
+            else (
+                app.state.config.RAG_AZURE_OPENAI_BASE_URL
+                if app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
+                else app.state.config.RAG_GEMINI_API_BASE_URL
+            )
         )
     ),
     (
@@ -887,7 +896,11 @@ app.state.EMBEDDING_FUNCTION = get_embedding_function(
         else (
             app.state.config.RAG_OLLAMA_API_KEY
             if app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
-            else app.state.config.RAG_AZURE_OPENAI_API_KEY
+            else (
+                app.state.config.RAG_AZURE_OPENAI_API_KEY
+                if app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
+                else app.state.config.RAG_GEMINI_API_KEY
+            )
         )
     ),
     app.state.config.RAG_EMBEDDING_BATCH_SIZE,

--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -776,7 +776,8 @@ def generate_gemini_batch_embeddings(
         embeddings = []
         
         # Process texts in batches to avoid API limits
-        batch_size = 5  # Gemini API has limits on batch size
+        from open_webui.config import RAG_EMBEDDING_BATCH_SIZE
+        batch_size = RAG_EMBEDDING_BATCH_SIZE.value  # Use configuration instead of hard-coded value
         for i in range(0, len(texts), batch_size):
             batch_texts = texts[i:i + batch_size]
             batch_embeddings = []

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -354,9 +354,9 @@ async def update_embedding_config(
                     request.app.state.config.RAG_OLLAMA_BASE_URL
                     if request.app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
                     else (
-                        request.app.state.config.RAG_AZURE_OPENAI_BASE_URL
-                        if request.app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
-                        else request.app.state.config.RAG_GEMINI_API_BASE_URL
+                        request.app.state.config.RAG_GEMINI_API_BASE_URL
+                        if request.app.state.config.RAG_EMBEDDING_ENGINE == "gemini"
+                        else request.app.state.config.RAG_AZURE_OPENAI_BASE_URL
                     )
                 )
             ),
@@ -367,9 +367,9 @@ async def update_embedding_config(
                     request.app.state.config.RAG_OLLAMA_API_KEY
                     if request.app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
                     else (
-                        request.app.state.config.RAG_AZURE_OPENAI_API_KEY
-                        if request.app.state.config.RAG_EMBEDDING_ENGINE == "azure_openai"
-                        else request.app.state.config.RAG_GEMINI_API_KEY
+                        request.app.state.config.RAG_GEMINI_API_KEY
+                        if request.app.state.config.RAG_EMBEDDING_ENGINE == "gemini"
+                        else request.app.state.config.RAG_AZURE_OPENAI_API_KEY
                     )
                 )
             ),
@@ -1247,7 +1247,11 @@ def save_docs_to_vector_db(
                 else (
                     request.app.state.config.RAG_OLLAMA_BASE_URL
                     if request.app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
-                    else request.app.state.config.RAG_AZURE_OPENAI_BASE_URL
+                    else (
+                        request.app.state.config.RAG_GEMINI_API_BASE_URL
+                        if request.app.state.config.RAG_EMBEDDING_ENGINE == "gemini"
+                        else request.app.state.config.RAG_AZURE_OPENAI_BASE_URL
+                    )
                 )
             ),
             (
@@ -1256,7 +1260,11 @@ def save_docs_to_vector_db(
                 else (
                     request.app.state.config.RAG_OLLAMA_API_KEY
                     if request.app.state.config.RAG_EMBEDDING_ENGINE == "ollama"
-                    else request.app.state.config.RAG_AZURE_OPENAI_API_KEY
+                    else (
+                        request.app.state.config.RAG_GEMINI_API_KEY
+                        if request.app.state.config.RAG_EMBEDDING_ENGINE == "gemini"
+                        else request.app.state.config.RAG_AZURE_OPENAI_API_KEY
+                    )
                 )
             ),
             request.app.state.config.RAG_EMBEDDING_BATCH_SIZE,

--- a/src/lib/apis/retrieval/index.ts
+++ b/src/lib/apis/retrieval/index.ts
@@ -185,17 +185,23 @@ type OpenAIConfigForm = {
 };
 
 type AzureOpenAIConfigForm = {
-	key: string;
-	url: string;
-	version: string;
+        key: string;
+        url: string;
+        version: string;
+};
+
+type GeminiConfigForm = {
+        key: string;
+        url: string;
 };
 
 type EmbeddingModelUpdateForm = {
-	openai_config?: OpenAIConfigForm;
-	azure_openai_config?: AzureOpenAIConfigForm;
-	embedding_engine: string;
-	embedding_model: string;
-	embedding_batch_size?: number;
+        openai_config?: OpenAIConfigForm;
+        azure_openai_config?: AzureOpenAIConfigForm;
+        gemini_config?: GeminiConfigForm;
+        embedding_engine: string;
+        embedding_model: string;
+        embedding_batch_size?: number;
 };
 
 export const updateEmbeddingConfig = async (token: string, payload: EmbeddingModelUpdateForm) => {

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -112,7 +112,9 @@
 		console.debug('Update embedding model attempt:', embeddingModel);
 
 		updateEmbeddingModelLoading = true;
-		const res = await updateEmbeddingConfig(localStorage.token, {
+		
+		// Debug: Log the payload being sent
+		const payload = {
 			embedding_engine: embeddingEngine,
 			embedding_model: embeddingModel,
 			embedding_batch_size: embeddingBatchSize,
@@ -124,16 +126,20 @@
 				key: OpenAIKey,
 				url: OpenAIUrl
 			},
-                        azure_openai_config: {
-                                key: AzureOpenAIKey,
-                                url: AzureOpenAIUrl,
-                                version: AzureOpenAIVersion
-                        },
-                        gemini_config: {
-                                key: GeminiKey,
-                                url: GeminiUrl
-                        }
-                }).catch(async (error) => {
+			azure_openai_config: {
+				key: AzureOpenAIKey,
+				url: AzureOpenAIUrl,
+				version: AzureOpenAIVersion
+			},
+			gemini_config: {
+				key: GeminiKey,
+				url: GeminiUrl
+			}
+		};
+		
+		console.debug('Embedding config payload:', payload);
+		
+		const res = await updateEmbeddingConfig(localStorage.token, payload).catch(async (error) => {
 			toast.error(`${error}`);
 			await setEmbeddingConfig();
 			return null;
@@ -724,7 +730,8 @@
                 } else if (e.target.value === 'azure_openai') {
                         embeddingModel = 'text-embedding-3-small';
                 } else if (e.target.value === 'gemini') {
-                        embeddingModel = 'Gemini-Embedding-001';
+                        embeddingModel = 'gemini-embedding-exp-03-07';
+                        GeminiUrl = 'https://generativelanguage.googleapis.com/v1beta/models/';
                 } else if (e.target.value === '') {
                         embeddingModel = 'sentence-transformers/all-MiniLM-L6-v2';
                 }

--- a/src/lib/components/admin/Settings/Documents.svelte
+++ b/src/lib/components/admin/Settings/Documents.svelte
@@ -46,9 +46,12 @@
 	let OpenAIUrl = '';
 	let OpenAIKey = '';
 
-	let AzureOpenAIUrl = '';
-	let AzureOpenAIKey = '';
-	let AzureOpenAIVersion = '';
+        let AzureOpenAIUrl = '';
+        let AzureOpenAIKey = '';
+        let AzureOpenAIVersion = '';
+
+        let GeminiUrl = 'https://generativelanguage.googleapis.com/v1beta';
+        let GeminiKey = '';
 
 	let OllamaUrl = '';
 	let OllamaKey = '';
@@ -94,13 +97,17 @@
 			toast.error($i18n.t('OpenAI URL/Key required.'));
 			return;
 		}
-		if (
-			embeddingEngine === 'azure_openai' &&
-			(AzureOpenAIKey === '' || AzureOpenAIUrl === '' || AzureOpenAIVersion === '')
-		) {
-			toast.error($i18n.t('OpenAI URL/Key required.'));
-			return;
-		}
+                if (
+                        embeddingEngine === 'azure_openai' &&
+                        (AzureOpenAIKey === '' || AzureOpenAIUrl === '' || AzureOpenAIVersion === '')
+                ) {
+                        toast.error($i18n.t('OpenAI URL/Key required.'));
+                        return;
+                }
+                if (embeddingEngine === 'gemini' && GeminiKey === '') {
+                        toast.error($i18n.t('Gemini API Key is required.'));
+                        return;
+                }
 
 		console.debug('Update embedding model attempt:', embeddingModel);
 
@@ -117,12 +124,16 @@
 				key: OpenAIKey,
 				url: OpenAIUrl
 			},
-			azure_openai_config: {
-				key: AzureOpenAIKey,
-				url: AzureOpenAIUrl,
-				version: AzureOpenAIVersion
-			}
-		}).catch(async (error) => {
+                        azure_openai_config: {
+                                key: AzureOpenAIKey,
+                                url: AzureOpenAIUrl,
+                                version: AzureOpenAIVersion
+                        },
+                        gemini_config: {
+                                key: GeminiKey,
+                                url: GeminiUrl
+                        }
+                }).catch(async (error) => {
 			toast.error(`${error}`);
 			await setEmbeddingConfig();
 			return null;
@@ -222,14 +233,17 @@
 			OpenAIKey = embeddingConfig.openai_config.key;
 			OpenAIUrl = embeddingConfig.openai_config.url;
 
-			OllamaKey = embeddingConfig.ollama_config.key;
-			OllamaUrl = embeddingConfig.ollama_config.url;
+                        OllamaKey = embeddingConfig.ollama_config.key;
+                        OllamaUrl = embeddingConfig.ollama_config.url;
 
-			AzureOpenAIKey = embeddingConfig.azure_openai_config.key;
-			AzureOpenAIUrl = embeddingConfig.azure_openai_config.url;
-			AzureOpenAIVersion = embeddingConfig.azure_openai_config.version;
-		}
-	};
+                        AzureOpenAIKey = embeddingConfig.azure_openai_config.key;
+                        AzureOpenAIUrl = embeddingConfig.azure_openai_config.url;
+                        AzureOpenAIVersion = embeddingConfig.azure_openai_config.version;
+
+                        GeminiKey = embeddingConfig.gemini_config.key;
+                        GeminiUrl = embeddingConfig.gemini_config.url;
+                }
+        };
 	onMount(async () => {
 		await setEmbeddingConfig();
 
@@ -707,18 +721,21 @@
 												embeddingModel = '';
 											} else if (e.target.value === 'openai') {
 												embeddingModel = 'text-embedding-3-small';
-											} else if (e.target.value === 'azure_openai') {
-												embeddingModel = 'text-embedding-3-small';
-											} else if (e.target.value === '') {
-												embeddingModel = 'sentence-transformers/all-MiniLM-L6-v2';
-											}
+                } else if (e.target.value === 'azure_openai') {
+                        embeddingModel = 'text-embedding-3-small';
+                } else if (e.target.value === 'gemini') {
+                        embeddingModel = 'Gemini-Embedding-001';
+                } else if (e.target.value === '') {
+                        embeddingModel = 'sentence-transformers/all-MiniLM-L6-v2';
+                }
 										}}
 									>
 										<option value="">{$i18n.t('Default (SentenceTransformers)')}</option>
 										<option value="ollama">{$i18n.t('Ollama')}</option>
-										<option value="openai">{$i18n.t('OpenAI')}</option>
-										<option value="azure_openai">Azure OpenAI</option>
-									</select>
+                                                                               <option value="openai">{$i18n.t('OpenAI')}</option>
+                                                                               <option value="azure_openai">Azure OpenAI</option>
+                                                                               <option value="gemini">{$i18n.t('Gemini')}</option>
+                                                                        </select>
 								</div>
 							</div>
 
@@ -748,27 +765,38 @@
 										required={false}
 									/>
 								</div>
-							{:else if embeddingEngine === 'azure_openai'}
-								<div class="my-0.5 flex flex-col gap-2 pr-2 w-full">
-									<div class="flex gap-2">
-										<input
-											class="flex-1 w-full text-sm bg-transparent outline-hidden"
-											placeholder={$i18n.t('API Base URL')}
-											bind:value={AzureOpenAIUrl}
-											required
-										/>
-										<SensitiveInput placeholder={$i18n.t('API Key')} bind:value={AzureOpenAIKey} />
-									</div>
-									<div class="flex gap-2">
-										<input
-											class="flex-1 w-full text-sm bg-transparent outline-hidden"
-											placeholder="Version"
-											bind:value={AzureOpenAIVersion}
-											required
-										/>
-									</div>
-								</div>
-							{/if}
+                                                        {:else if embeddingEngine === 'azure_openai'}
+                                                                <div class="my-0.5 flex flex-col gap-2 pr-2 w-full">
+                                                                        <div class="flex gap-2">
+                                                                                <input
+                                                                                        class="flex-1 w-full text-sm bg-transparent outline-hidden"
+                                                                                        placeholder={$i18n.t('API Base URL')}
+                                                                                        bind:value={AzureOpenAIUrl}
+                                                                                        required
+                                                                                />
+                                                                                <SensitiveInput placeholder={$i18n.t('API Key')} bind:value={AzureOpenAIKey} />
+                                                                        </div>
+                                                                        <div class="flex gap-2">
+                                                                                <input
+                                                                                        class="flex-1 w-full text-sm bg-transparent outline-hidden"
+                                                                                        placeholder="Version"
+                                                                                        bind:value={AzureOpenAIVersion}
+                                                                                        required
+                                                                                />
+                                                                        </div>
+                                                                </div>
+                                                        {:else if embeddingEngine === 'gemini'}
+                                                                <div class="my-0.5 flex gap-2 pr-2">
+                                                                        <input
+                                                                                class="flex-1 w-full text-sm bg-transparent outline-hidden"
+                                                                                placeholder={$i18n.t('API Base URL')}
+                                                                                bind:value={GeminiUrl}
+                                                                                required
+                                                                        />
+
+                                                                        <SensitiveInput placeholder={$i18n.t('API Key')} bind:value={GeminiKey} />
+                                                                </div>
+                                                        {/if}
 						</div>
 
 						<div class="  mb-2.5 flex flex-col w-full">
@@ -864,7 +892,7 @@
 							</div>
 						</div>
 
-						{#if embeddingEngine === 'ollama' || embeddingEngine === 'openai' || embeddingEngine === 'azure_openai'}
+                                                {#if embeddingEngine === 'ollama' || embeddingEngine === 'openai' || embeddingEngine === 'azure_openai' || embeddingEngine === 'gemini'}
 							<div class="  mb-2.5 flex w-full justify-between">
 								<div class=" self-center text-xs font-medium">
 									{$i18n.t('Embedding Batch Size')}


### PR DESCRIPTION
## Summary
- add Gemini API config for embeddings
- support Gemini in backend retrieval utils and router
- initialize Gemini settings in main
- extend frontend admin settings to configure Gemini
- update API types for Gemini

## Testing
- `npm run test:frontend` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68711703ff3c8332bff0107167ea65df